### PR TITLE
Patch to fix issues during jumpbox build

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -8,6 +8,7 @@ build_root_path: "{{ binary_builder_path }}/build"
 bosh_packages:
 - name: mysql-5.1.62
   url: http://dev.mysql.com/get/Downloads/MySQL-5.0/mysql-5.1.62.tar.gz
+  object: ''
   slug: mysql
   action: compile
   script: bosh-release/mysql-client.sh
@@ -15,7 +16,8 @@ bosh_packages:
   bosh_blob: server-5.1.62-rel13.3-435-Linux-ppc64le.tar.gz
   bosh_blob_name: server-5.1.62-rel13.3-435-Linux-ppc64le
 - name: postgresql-9.0.3
-  url: https://blob.cfblob.com/rest/objects/4e4e78bca61e121004e4e7d51d950e04fbd4f2ca2d89
+  url: ''
+  object: rest/objects/4e4e78bca61e121004e4e7d51d950e04fbd4f2ca2d89
   slug: postgres
   action: compile
   script: postgres.sh
@@ -23,28 +25,32 @@ bosh_packages:
   bosh_blob: postgres-9.0.3-1.ppc64le.tar.gz
   bosh_blob_name: postgres-9.0.3-1.ppc64le
 - name: postgresql-9.0.3
-  url: https://blob.cfblob.com/rest/objects/4e4e78bca61e121004e4e7d51d950e04fbd4f2ca2d89
+  url: '' 
+  object: rest/objects/4e4e78bca61e121004e4e7d51d950e04fbd4f2ca2d89
   slug: postgres_for_libpq
   action: change_config
   bosh_blob_path: postgres
   bosh_blob: postgresql-9.0.3.tar.gz
   bosh_blob_name: postgresql-9.0.3
 - name: redis-2.6.9
-  url: https://blob.cfblob.com/d24e2fbd-ea3f-4c4b-b4e3-a0ccfd60dafa
+  url: ''
+  object: d24e2fbd-ea3f-4c4b-b4e3-a0ccfd60dafa
   slug: redis
   action: change_config
   bosh_blob_path: redis
   bosh_blob: redis-2.6.9.tar.gz
   bosh_blob_name: redis-2.6.9
 - name: ruby-2.1.4
-  url: https://blob.cfblob.com/00b50c34-f264-4245-9a90-b56c7385694e
+  url: ''
+  object: 00b50c34-f264-4245-9a90-b56c7385694e
   slug: ruby
   action: change_config
   bosh_blob_path: ruby
   bosh_blob: ruby-2.1.4.tar.gz
   bosh_blob_name: ruby-2.1.4
 - name: yaml-0.1.5
-  url: https://blob.cfblob.com/db07c821-62f8-4fd1-a99a-ff1c88b2474b
+  url: ''
+  object: db07c821-62f8-4fd1-a99a-ff1c88b2474b
   slug: yaml
   action: change_config
   bosh_blob_path: ruby
@@ -53,6 +59,7 @@ bosh_packages:
 - name: powerdns-3.7.3
   url: https://github.com/PowerDNS/pdns/archive/rec-3.7.3.tar.gz
   slug: powerdns
+  object: ''
   action: compile
   script: bosh-release/power-dns.sh
   bosh_blob_path: powerdns
@@ -61,28 +68,32 @@ bosh_packages:
 
 cf_packages:
 - name: yaml-0.1.6
-  url: https://blob.cfblob.com/b3ed7d5e-4c46-4c81-8ac7-04d070dd9cc8
+  url: ''
+  object: b3ed7d5e-4c46-4c81-8ac7-04d070dd9cc8
   slug: yaml_cf
   action: change_config
   bosh_blob_path: ruby-2.1.4
   bosh_blob: yaml-0.1.6.tar.gz
   bosh_blob_name: yaml-0.1.6
 - name: ruby-2.1.4
-  url: https://blob.cfblob.com/00b50c34-f264-4245-9a90-b56c7385694e
+  url: ''
+  object: 00b50c34-f264-4245-9a90-b56c7385694e
   slug: ruby_cf
   action: change_config
   bosh_blob_path: ruby-2.1.4
   bosh_blob: ruby-2.1.4.tar.gz
   bosh_blob_name: ruby-2.1.4
 - name: postgresql-9.0.3
-  url: https://blob.cfblob.com/rest/objects/4e4e78bca61e121004e4e7d51d950e04fbd4f2ca2d89
+  url: ''
+  object: rest/objects/4e4e78bca61e121004e4e7d51d950e04fbd4f2ca2d89
   slug: postgres
   action: change_config
   bosh_blob_path: postgres
   bosh_blob: postgresql-9.0.3.tar.gz
   bosh_blob_name: postgresql-9.0.3
 - name: postgresql-9.0.3
-  url: https://blob.cfblob.com/rest/objects/4e4e78bca61e121004e4e7d51d950e04fbd4f2ca2d89
+  url: ''
+  object: rest/objects/4e4e78bca61e121004e4e7d51d950e04fbd4f2ca2d89
   slug: postgres
   action: compile
   script: postgres.sh
@@ -91,6 +102,7 @@ cf_packages:
   bosh_blob_name: postgres-9.0.3-1.ppc64le
 - name: mysql-5.1.62
   url: http://dev.mysql.com/get/Downloads/MySQL-5.0/mysql-5.1.62.tar.gz
+  object: ''
   slug: mysql_cf
   action: compile
   script: cf-release/mysql-client.sh
@@ -99,6 +111,7 @@ cf_packages:
   bosh_blob_name: client-5.1.62-rel13.3-435-Linux-ppc64le
 - name: openjdk-1.7.0
   url: ''
+  object: ''
   slug: openjdk
   action: compile
   script: cf-release/openjdk.sh
@@ -107,6 +120,7 @@ cf_packages:
   bosh_blob_name: java-7-openjdk-ppc64el
 - name: gcc-5.1.0
   url: ftp://ftp.gnu.org/gnu/gcc/gcc-5.1.0/gcc-5.1.0.tar.gz
+  object: ''
   slug: gccgo
   action: compile
   script: cf-release/gccgo_ppc64le_trusty.sh
@@ -115,6 +129,7 @@ cf_packages:
   bosh_blob_name: gccgo
 - name: rootfs
   url: ''
+  object: ''
   slug: rootfs
   action: compile
   script: cf-release/rootfs.sh
@@ -123,6 +138,7 @@ cf_packages:
   bosh_blob_name: rootfsppc64
 - name: dea_next_gems
   url: ''
+  object: ''
   slug: dea_next
   action: compile
   script: cf-release/dea_next_gems.sh
@@ -131,6 +147,7 @@ cf_packages:
   bosh_blob_name: dea_next_gems_vendor_cache
 - name: debian_nfs_server
   url: ''
+  object: ''
   slug: nfs
   action: compile
   script: cf-release/nfs-kernel-server.sh

--- a/roles/binaries-builder/files/scripts/cf-release/nfs-kernel-server.sh
+++ b/roles/binaries-builder/files/scripts/cf-release/nfs-kernel-server.sh
@@ -9,6 +9,6 @@ if [ "$(id -u)" != "0" ]; then
   exit 1
 fi
 
-apt-get -y -d install nfs-kernel-server=1:1.2.8-6ubuntu1.1 
+apt-get -y -d install nfs-kernel-server=1:1.2.8-6ubuntu1.2
 
-cp /var/cache/apt/archives/nfs-kernel-server_1%3a1.2.8-6ubuntu1.1_ppc64el.deb $bosh_blob
+cp /var/cache/apt/archives/nfs-kernel-server_1%3a1.2.8-6ubuntu1.2_ppc64el.deb $bosh_blob

--- a/roles/binaries-builder/tasks/binaries-builder.yml
+++ b/roles/binaries-builder/tasks/binaries-builder.yml
@@ -21,6 +21,17 @@
   until: not result|failed
   retries: 5
 
+- name: "Fetch {{ workspace }} binaries with s3cli"
+  shell: "s3cli -c {{github_path}}/s3cli/s3.json get {{item.object}} {{ sources_root_path }}/{{ workspace }}/{{ item.name }}.tar.gz"
+  when: item.object
+  sudo: no
+  with_items:
+    "{{ packages }}"
+  register: result
+  environment: '{{go_environment}}'
+  until: not result|failed
+  retries: 5
+
 - name: "Copy install scripts"
   copy: "src=roles/binaries-builder/files/scripts"
   args:

--- a/roles/common/tasks/install_bosh.yml
+++ b/roles/common/tasks/install_bosh.yml
@@ -19,7 +19,7 @@
   environment: ruby_environment
 
 - name: Install BOSH gems
-  shell: "bundle install --deployment"
+  shell: "gem install -v 1.10.6 bundler --no-rdoc --no-ri; bundle _1.10.6_ install --deployment"
   args:
     chdir: "{{ bosh_path }}"
   sudo: no

--- a/roles/common/tasks/install_github_projects.yml
+++ b/roles/common/tasks/install_github_projects.yml
@@ -31,6 +31,42 @@
   until: not result|failed
   retries: 5
 
+- name: Clone s3cli
+  git: "repo=https://github.com/pivotal-golang/s3cli.git dest={{github_path}}/s3cli accept_hostkey=yes"
+  sudo: no
+  register: result
+  until: not result|failed
+  retries: 10
+
+- name: Build s3cli
+  shell: "GOPATH=GOPATH:{{github_path}}/s3cli;go build -o s3cli s3cli/s3cli chdir={{github_path}}/s3cli creates={{github_path}}/s3cli/s3cli"
+  sudo: no
+  environment: '{{go_environment}}'
+  register: result
+  until: not result|failed
+  retries: 5
+
+- name: Copy s3cli binary to /usr/local/bin
+  shell: "cp {{github_path}}/s3cli/s3cli /usr/local/bin/s3cli creates=/usr/local/bin/s3cli"
+  sudo: yes
+  register: result
+  until: not result|failed
+  retries: 5
+
+- name: Make s3cli file executable
+  file: path=/usr/local/bin/s3cli mode=755
+  sudo: yes
+  register: result
+  until: not result|failed
+  retries: 5
+
+- name: Create s3cli config file
+  shell: "echo '{\"bucket_name\":\"blob.cfblob.com\"}' > {{github_path}}/s3cli/s3.json"
+  sudo: no
+  register: result
+  until: not result|failed
+  retries: 5
+
 - name: Add direnv load to .bashrc
   shell: echo 'eval "$(direnv hook bash)"' >> /home/{{ansible_ssh_user}}/.bashrc
   sudo: no

--- a/roles/stemcell-builder/tasks/create_environment.yml
+++ b/roles/stemcell-builder/tasks/create_environment.yml
@@ -12,6 +12,10 @@
   copy: "src=Gemfile dest={{stemcell_builder_path}}/Gemfile"
 
 # git clone --recursive --branch power-2915 https://github.com/Altoros/bosh.git
+- name: "Check if {{stemcell_builder_path}}/bosh exists"
+  stat: "path={{stemcell_builder_path}}/bosh"
+  register: bosh_stemcell_folder
+
 - name: Clone BOSH repo from Altoros github for stemcell builder
   git: "repo=https://github.com/Altoros/bosh.git"
   sudo: no
@@ -21,6 +25,7 @@
     recursive: yes
     accept_hostkey: yes
   register: result
+  when: bosh_stemcell_folder.stat.exists == False
   until: not result|failed
   retries: 5
 


### PR DESCRIPTION
This patch adds:
- s3cli usage to be able to download blobs from http://blob.cfblob.com/
- change information about blobs for s3cli usage
- fix bundler version to avoid the issue https://stackoverflow.com/questions/34276324/travis-reports-odd-message-of-corrupted-gemfile-lock
- add the statement to check whether BOSH repository was already downloaded
- fix package versions